### PR TITLE
Generate archives with minified jre included (jlink)

### DIFF
--- a/binary/build.gradle
+++ b/binary/build.gradle
@@ -1,0 +1,80 @@
+import org.beryx.runtime.util.Util
+
+plugins {
+    id 'java'
+    id 'org.beryx.runtime' version '1.12.6'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(':cli')
+}
+
+application {
+    mainClass = 'com.adaptivescale.rosetta.cli.Main'
+    applicationName = 'rosetta'
+}
+
+ext{
+    imageName='rosetta-'+project.version+'.zip'
+    imageFile = Util.createRegularFileProperty(project)
+    imageFile.set(project.layout.buildDirectory.file(imageName))
+}
+
+runtime {
+    options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
+    modules = ['java.base', 'java.naming', 'java.xml', 'java.sql', 'java.rmi', 'java.management']
+
+    targetPlatform("linux-x64") {
+        imageZip = project.ext.imageFile
+        jdkHome = jdkDownload("https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/OpenJDK11U-jdk_x64_linux_hotspot_11.0.9.1_1.tar.gz") {
+            downloadDir = "$buildDir/jdklinux"
+            archiveName = "linux-x64"
+            archiveExtension = "tar.gz"
+            pathToHome = "jdk-11.0.9.1+1/"
+            overwrite = true
+        }
+    }
+
+    targetPlatform("mac_x64") {
+        imageZip = project.ext.imageFile
+        jdkHome = jdkDownload("https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/OpenJDK11U-jdk_x64_mac_hotspot_11.0.9.1_1.tar.gz") {
+            downloadDir = "$buildDir/jdkmac"
+            archiveName = "mac"
+            archiveExtension = "tar.gz"
+            pathToHome = "jdk-11.0.9.1+1/Contents/Home"
+            overwrite = true
+        }
+    }
+
+    targetPlatform("mac_aarch64") {
+        imageZip = project.ext.imageFile
+        jdkHome = jdkDownload("https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-macosx_aarch64.tar.gz") {
+            downloadDir = "$buildDir/jdkmac_arm"
+            archiveName = "mac_arm"
+            archiveExtension = "tar.gz"
+            pathToHome = "zulu11.56.19-ca-jdk11.0.15-macosx_aarch64/zulu-11.jdk/Contents/Home"
+            overwrite = true
+        }
+    }
+
+    targetPlatform("win_x64") {
+        imageZip = project.ext.imageFile
+        jdkHome = jdkDownload("https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/OpenJDK11U-jdk_x64_windows_hotspot_11.0.9.1_1.zip") {
+            downloadDir = "$buildDir/jdkwin"
+            archiveName = "win"
+            archiveExtension = "zip"
+            pathToHome = "jdk-11.0.9.1+1"
+            overwrite = true
+        }
+    }
+
+    launcher {
+        def resourcesDir = sourceSets.main.resources.srcDirs.first().absolutePath
+        unixScriptTemplate = file("file:/${resourcesDir}/unix_template.txt")
+        windowsScriptTemplate = file("file:/${resourcesDir}/windows_template.txt")
+    }
+}

--- a/binary/src/main/resources/unix_template.txt
+++ b/binary/src/main/resources/unix_template.txt
@@ -1,0 +1,170 @@
+#!/usr/bin/env sh
+
+##############################################################################
+##
+##  ${applicationName} start up script for UN*X
+##
+##############################################################################
+
+# Attempt to set APP_HOME
+# Resolve links: \$0 may be a link
+PRG="\$0"
+# Need this for relative symlinks.
+while [ -h "\$PRG" ] ; do
+    ls=`ls -ld "\$PRG"`
+    link=`expr "\$ls" : '.*-> \\(.*\\)\$'`
+    if expr "\$link" : '/.*' > /dev/null; then
+        PRG="\$link"
+    else
+        PRG=`dirname "\$PRG"`"/\$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"\$PRG\"`/${appHomeRelativePath}" >/dev/null
+APP_HOME="`pwd -P`"
+cd "\$SAVED" >/dev/null
+
+APP_NAME="${applicationName}"
+APP_BASE_NAME=`basename "\$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
+DEFAULT_JVM_OPTS=${defaultJvmOpts}
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn () {
+    echo "\$*"
+}
+
+die () {
+    echo
+    echo "\$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
+
+CLASSPATH="\$APP_HOME/lib/*"
+
+if [ x"\${ROSETTA_DRIVERS}" = "x" ]; then
+    DRIVERS_PATH="\${APP_HOME}/drivers/"
+    mkdir -p \$DRIVERS_PATH
+    CLASSPATH="\${CLASSPATH}:\${DRIVERS_PATH}*"
+else
+    CLASSPATH="\${CLASSPATH}:\${ROSETTA_DRIVERS}*"
+fi
+
+JAVA_HOME="\$APP_HOME"
+JAVACMD="\$JAVA_HOME/bin/java"
+
+# Increase the maximum file descriptors if we can.
+if [ "\$cygwin" = "false" -a "\$darwin" = "false" -a "\$nonstop" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ \$? -eq 0 ] ; then
+        if [ "\$MAX_FD" = "maximum" -o "\$MAX_FD" = "max" ] ; then
+            MAX_FD="\$MAX_FD_LIMIT"
+        fi
+        ulimit -n \$MAX_FD
+        if [ \$? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: \$MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: \$MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if \$darwin; then
+    GRADLE_OPTS="\$GRADLE_OPTS \\"-Xdock:name=\$APP_NAME\\" \\"-Xdock:icon=\$APP_HOME/media/gradle.icns\\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if \$cygwin ; then
+    APP_HOME=`cygpath --path --mixed "\$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "\$CLASSPATH"`
+    JAVA_HOME="\$APP_HOME"
+    JAVACMD="\$JAVA_HOME/bin/java"
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in \$ROOTDIRSRAW ; do
+        ROOTDIRS="\$ROOTDIRS\$SEP\$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^(\$ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "\$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="\$OURCYGPATTERN|(\$GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "\$@" ; do
+        CHECK=`echo "\$arg"|egrep -c "\$OURCYGPATTERN" -`
+        CHECK2=`echo "\$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ \$CHECK -ne 0 ] && [ \$CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args\$i`=`cygpath --path --ignore --mixed "\$arg"`
+        else
+            eval `echo args\$i`="\"\$arg\""
+        fi
+        i=\$((i+1))
+    done
+    case \$i in
+        (0) set -- ;;
+        (1) set -- "\$args0" ;;
+        (2) set -- "\$args0" "\$args1" ;;
+        (3) set -- "\$args0" "\$args1" "\$args2" ;;
+        (4) set -- "\$args0" "\$args1" "\$args2" "\$args3" ;;
+        (5) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" ;;
+        (6) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" "\$args5" ;;
+        (7) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" "\$args5" "\$args6" ;;
+        (8) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" "\$args5" "\$args6" "\$args7" ;;
+        (9) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" "\$args5" "\$args6" "\$args7" "\$args8" ;;
+    esac
+fi
+
+# Escape application args
+save () {
+    for i do printf %s\\\\n "\$i" | sed "s/'/'\\\\\\\\''/g;1s/^/'/;\\\$s/\\\$/' \\\\\\\\/" ; done
+    echo " "
+}
+APP_ARGS=\$(save "\$@")
+
+<% if ( System.properties['BADASS_CDS_ARCHIVE_FILE_LINUX'] ) { %>
+CDS_ARCHIVE_FILE="<%= System.properties['BADASS_CDS_ARCHIVE_FILE_LINUX'] %>"
+CDS_JVM_OPTS="-XX:ArchiveClassesAtExit=\$CDS_ARCHIVE_FILE"
+if [ -f "\$CDS_ARCHIVE_FILE" ]; then
+    CDS_JVM_OPTS="-XX:SharedArchiveFile=\$CDS_ARCHIVE_FILE"
+fi
+<% } %>
+
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- \$DEFAULT_JVM_OPTS \$CDS_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar} <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %>-classpath "\"\$CLASSPATH\"" ${mainClassName} "\$APP_ARGS"
+
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [ "\$(uname)" = "Darwin" ] && [ "\$HOME" = "\$PWD" ]; then
+  cd "\$(dirname "\$0")"
+fi
+
+<% if ( System.properties['BADASS_RUN_IN_BIN_DIR'] ) { %>cd "\$APP_HOME/bin" && <% } %>exec "\$JAVACMD" "\$@"

--- a/binary/src/main/resources/windows_template.txt
+++ b/binary/src/main/resources/windows_template.txt
@@ -1,0 +1,83 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  ${applicationName} startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%${appHomeRelativePath}
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=${defaultJvmOpts}
+
+set JAVA_HOME="%APP_HOME%"
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+set JAVA_EXE="%JAVA_EXE:"=%"
+
+if exist %JAVA_EXE% goto init
+
+echo.
+echo ERROR: The directory %JAVA_HOME% does not contain a valid Java runtime for your platform.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%JAVA_HOME:"=%/lib/*
+
+if x%ROSETTA_DRIVERS% == x (
+    if not exist %APP_HOME%/drivers mkdir "%APP_HOME%/drivers/"
+    set CLASSPATH=%CLASSPATH%;%APP_HOME%/drivers/*
+) else (
+    set CLASSPATH=%CLASSPATH%;%ROSETTA_DRIVERS%*
+)
+
+<% if ( System.properties['BADASS_CDS_ARCHIVE_FILE_WINDOWS'] ) { %>
+set CDS_ARCHIVE_FILE="<%= System.properties['BADASS_CDS_ARCHIVE_FILE_WINDOWS'] %>"
+set CDS_JVM_OPTS=-XX:ArchiveClassesAtExit=%CDS_ARCHIVE_FILE%
+if exist %CDS_ARCHIVE_FILE% set CDS_JVM_OPTS=-XX:SharedArchiveFile=%CDS_ARCHIVE_FILE%
+<% } %>
+
+@rem Execute ${applicationName}
+<% if ( System.properties['BADASS_RUN_IN_BIN_DIR'] ) { %>pushd %DIRNAME% & <% } %>%JAVA_EXE% %DEFAULT_JVM_OPTS% %CDS_JVM_OPTS% %JAVA_OPTS% %${optsEnvironmentVar}% <% if ( appNameSystemProperty ) { %>"-D${appNameSystemProperty}=%APP_BASE_NAME%"<% } %> -classpath %CLASSPATH% ${mainClassName} %CMD_LINE_ARGS%<% if ( System.properties['BADASS_RUN_IN_BIN_DIR'] ) { %> & popd<% } %>
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable ${exitEnvironmentVar} if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%${exitEnvironmentVar}%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/ddl/build.gradle
+++ b/ddl/build.gradle
@@ -2,8 +2,6 @@ plugins {
     id 'java'
 }
 
-group 'org.example'
-version '1.0-SNAPSHOT'
 
 repositories {
     mavenCentral()
@@ -12,7 +10,6 @@ repositories {
 dependencies {
 
     implementation project(':common')
-
 
     testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.3'
     testImplementation project(':translator')

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,4 +5,5 @@ include 'translator'
 include 'ddl'
 include 'cli'
 include 'common'
+include 'binary'
 


### PR DESCRIPTION
use plugin: https://badass-runtime-plugin.beryx.org to generate archives with minified jre included (jlink)

If the env var ROSETTA_DRIVERS is set, cli will load drivers from this directory otherwise it will create 'drivers' directory in root of the archive

Use gradle task **_runtime_**  to generate images

How to run: go to /bin & run rosetta or rosetta.bash