### PR TITLE
Change logic how assertions in BigQuery for arrays are run.

### DIFF
--- a/test/src/main/java/com/adaptivescale/rosetta/test/assertion/generator/BigQueryAssertionSqlGenerator.java
+++ b/test/src/main/java/com/adaptivescale/rosetta/test/assertion/generator/BigQueryAssertionSqlGenerator.java
@@ -8,22 +8,31 @@ public class BigQueryAssertionSqlGenerator extends BaseAssertionSqlGenerator {
 
     @Override
     String prepareSql(Connection connection, Table table, Column column, String whereClauseCondition) {
+        String columnName = isArray(column) ? String.format("ARRAY_TO_STRING(%s,',')", column.getName()) : column.getName();
         return String.format("Select Count(*) from %s.%s.%s where %s %s",
                 connection.getDatabaseName(),
                 connection.getSchemaName(),
                 table.getName(),
-                column.getName(), whereClauseCondition);
+                columnName,
+                whereClauseCondition);
+    }
+
+    private boolean isArray(Column column) {
+        return "ARRAY".equals(column.getTypeName());
     }
 
     /**
-     * Use BigQuery function CAST ( x as y) to cast data types
+     * Use method to prepare value for sql 
      *
      * @param value  to cast
      * @param column model column
      * @return BigQuery function
      */
-     String castValue(Object value, Column column) {
+    String castValue(Object value, Column column) {
         String stringValue = value == null ? null : "\"" + value + "\"";
+        if (isArray(column)) {
+            return stringValue;
+        }
         return " CAST(" + stringValue + " as " + column.getTypeName() + ")";
     }
 }


### PR DESCRIPTION
Cast array field to string and in the test value write array values as comma separated value
example: value: 'a,b,c,d,e,t'